### PR TITLE
Changed `after` example in Chapter-12 (Events).

### DIFF
--- a/chapter-12/README.md
+++ b/chapter-12/README.md
@@ -49,7 +49,7 @@ engine.Before(before).Insert(&obj)
 This method will be called after any process. For example:
 
 ```Go
-before := func(bean interface{}){
+after := func(bean interface{}){
     fmt.Println("after", bean)
 }
 engine.After(after).Insert(&obj)


### PR DESCRIPTION
The `after` example had the variable named as before. It should be after.
