### PR TITLE
Add GonicMapper to  naming map rule

### DIFF
--- a/chapter-02/1.mapping.md
+++ b/chapter-02/1.mapping.md
@@ -1,6 +1,6 @@
 ### 2.1.name mapping rule
 
-use xorm.IMapper interface to implement. There are two IMapper implemented: `SnakeMapper` and `SameMapper`. SnakeMapper means struct name is word by word and table name or column name as 下划线. SameMapper means same name between struct and table.
+Use xorm.IMapper interface to set the name mapping rule. There are three rules: `SnakeMapper`, `SameMapper`, and `GonicMapper`. `SnakeMapper` inserts an `_` (underscore) between each word (Capital Case) to get the table name or column name. `SameMapper` uses the same name between the struct and table. `GonicMapper` is basically the same as SnakeMapper, but doesn't insert an underscore between commonly used acronyms. For example `ID` is converted to `id` in GonicMapper, but `ID` is converted to `i_d` in SnakeMapper.
 
 SnakeMapper is the default.
 


### PR DESCRIPTION
Add explanation about `GonicMapper` in naming map rules.
