### PR TITLE
Fixed typo in 2.updated.md

### DIFF
--- a/chapter-06/2.updated.md
+++ b/chapter-06/2.updated.md
@@ -14,10 +14,10 @@ When methods `Insert()`, `InsertOne()`, `Update()` will be called,  ，`updated`
 
 ```Go
 var user User
-engine.Id(1).Get(&user)
+engine.ID(1).Get(&user)
 // SELECT * FROM user WHERE id = ?
-engine.Id(1).Update(&user)
-// UPDATE user SET ..., updaetd_at = ? WHERE id = ?
+engine.ID(1).Update(&user)
+// UPDATE user SET ..., updated_at = ? WHERE id = ?
 ```
 
 If you will temporarilly stop filling the time, use `NoAutoTime()`:


### PR DESCRIPTION
Fix typo and changed from the Deprecated `Id` to `ID`